### PR TITLE
Only register one click listener

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -76,7 +76,7 @@
 
 			} else {
 
-				$( document ).on( 'click', selector, function( event ) {
+				$( document ).one( 'click', selector, function( event ) {
 
 					// console.log( isTouch );
 


### PR DESCRIPTION
This is the fix for a bug I had on mobile devices, where I needed to register a lot of swipebox instances on a single Page. The swipebox would start to open slower and slower because there were many click listerners on $(document) at the same time. Alternatively if a single click listeners is not wanted, please consider removing the listerner on destroy.